### PR TITLE
Add additional picker to insert file links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Simply press a key (`<C-l>` in insert mode by default) and select what you want 
 
 `insert_link` only works for elements in the current document.
 
+### Automatic File Link Insertion
+Simply press a key (`<C-f>` in insert mode by default) and select what Neorg file you want to link to.
+
+`insert_file_link` only works for elements in the current document.
+
 # Installation
 First, make sure to pull this plugin down. This plugin does not run any code in of itself. It requires Neorg
 to load it first:

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Simply press a key (`<C-l>` in insert mode by default) and select what you want 
 ### Automatic File Link Insertion
 Simply press a key (`<C-f>` in insert mode by default) and select what Neorg file you want to link to.
 
-`insert_file_link` only works for elements in the current document.
-
 # Installation
 First, make sure to pull this plugin down. This plugin does not run any code in of itself. It requires Neorg
 to load it first:

--- a/lua/neorg/modules/core/integrations/telescope/module.lua
+++ b/lua/neorg/modules/core/integrations/telescope/module.lua
@@ -17,12 +17,13 @@ module.load = function()
 
 	telescope.load_extension("neorg")
 
-	module.required["core.keybinds"].register_keybinds(module.name, { "find_linkable", "insert_link", "search_headings" })
+	module.required["core.keybinds"].register_keybinds(module.name, { "find_linkable", "insert_link", "insert_file_link", "search_headings" })
 end
 
 module.public = {
 	find_linkable = require("telescope._extensions.neorg.find_linkable"),
 	insert_link = require("telescope._extensions.neorg.insert_link"),
+	insert_file_link = require("telescope._extensions.neorg.insert_file_link"),
 	search_headings = require("telescope._extensions.neorg.search_headings"),
 }
 
@@ -31,6 +32,8 @@ module.on_event = function(event)
 		module.public.find_linkable()
 	elseif event.split_type[2] == "core.integrations.telescope.insert_link" then
 		module.public.insert_link()
+	elseif event.split_type[2] == "core.integrations.telescope.insert_file_link" then
+		module.public.insert_file_link()
 	elseif event.split_type[2] == "core.integrations.telescope.search_headings" then
 		module.public.search_headings()
 	end
@@ -40,6 +43,7 @@ module.events.subscribed = {
 	["core.keybinds"] = {
 		["core.integrations.telescope.find_linkable"] = true,
 		["core.integrations.telescope.insert_link"] = true,
+		["core.integrations.telescope.insert_file_link"] = true,
 		["core.integrations.telescope.search_headings"] = true,
 	},
 }

--- a/lua/telescope/_extensions/neorg.lua
+++ b/lua/telescope/_extensions/neorg.lua
@@ -2,6 +2,7 @@ return require("telescope").register_extension({
 	exports = {
 		find_linkable = require("neorg.modules.core.integrations.telescope.module").public.find_linkable,
 		insert_link = require("neorg.modules.core.integrations.telescope.module").public.insert_link,
+		insert_file_link = require("neorg.modules.core.integrations.telescope.module").public.insert_file_link,
 		search_headings = require("neorg.modules.core.integrations.telescope.module").public.search_headings,
 	},
 })

--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -78,16 +78,16 @@ return function(opts)
                 local entry = state.get_selected_entry()
                 actions.close(prompt_bufnr)
 
-                local file_path_sans_norg_extension, _ = entry.value.file:gsub("%.norg$", "")
-                local just_file_name, _ = file_path_sans_norg_extension:gsub(".*%/", "")
+                local path_no_extension, _ = entry.value.file:gsub("%.norg$", "")
+                local file_name, _ = path_no_extension:gsub(".*%/", "")
 
                 vim.api.nvim_put(
                     {
                         "{"
-                            .. ":$/" .. file_path_sans_norg_extension .. ":"
+                            .. ":$/" .. path_no_extension .. ":"
                             .. "}"
                             .. "["
-                            .. just_file_name
+                            .. file_name
                             .. "]",
                     },
                     "c",

--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -42,24 +42,13 @@ local function generate_links()
     end
 
     for _, file in pairs(files[2]) do
---         local full_path_file = files[1] .. "/" .. file
---         local bufnr = dirman.get_file_bufnr(full_path_file)
---         if not bufnr then
---             return
---         end
+        local full_path_file = files[1] .. "/" .. file
+        local bufnr = dirman.get_file_bufnr(full_path_file)
 
---         -- Because we do not want file name to appear in a link to the same file
---         local file_inserted = (function ()
---             if vim.api.nvim_get_current_buf() == bufnr then
---                 return nil
---             else
---                 return file
---             end
---         end)()
-
-        local links = {file = file}
-
-        table.insert(res, links)
+        if vim.api.nvim_get_current_buf() ~= bufnr then
+          local links = {file = file}
+          table.insert(res, links)
+        end
     end
 
     return res

--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -1,0 +1,113 @@
+local actions = require("telescope.actions")
+local actions_set = require("telescope.actions.set")
+local state = require('telescope.actions.state')
+local finders = require("telescope.finders")
+local pickers = require("telescope.pickers")
+local conf = require("telescope.config").values
+
+local neorg_loaded, _ = pcall(require, "neorg.modules")
+
+assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first")
+
+--- Get a list of all norg files in current workspace. Returns { workspace_path, norg_files }
+--- @return table
+local function get_norg_files()
+    local dirman = neorg.modules.get_module("core.norg.dirman")
+
+    if not dirman then
+        return nil
+    end
+
+    local current_workspace = dirman.get_current_workspace()
+
+    local norg_files = dirman.get_norg_files(current_workspace[1])
+
+    return { current_workspace[2], norg_files }
+end
+
+--- Generate links for telescope
+--- @return table
+local function generate_links()
+    local res = {}
+    local dirman = neorg.modules.get_module("core.norg.dirman")
+
+    if not dirman then
+        return nil
+    end
+
+    local files = get_norg_files()
+
+    if not files[2] then
+        return
+    end
+
+    for _, file in pairs(files[2]) do
+--         local full_path_file = files[1] .. "/" .. file
+--         local bufnr = dirman.get_file_bufnr(full_path_file)
+--         if not bufnr then
+--             return
+--         end
+
+--         -- Because we do not want file name to appear in a link to the same file
+--         local file_inserted = (function ()
+--             if vim.api.nvim_get_current_buf() == bufnr then
+--                 return nil
+--             else
+--                 return file
+--             end
+--         end)()
+
+        local links = {file = file}
+
+        table.insert(res, links)
+    end
+
+    return res
+end
+
+return function(opts)
+    opts = opts or {}
+
+    pickers.new(opts, {
+        prompt_title = "Insert Link to norg File",
+        results_title = "Linkables",
+        finder = finders.new_table({
+            results = generate_links(),
+            entry_maker = function(entry)
+                return {
+                    value = entry,
+                    display = entry.file,
+                    ordinal = entry.file,
+                }
+            end,
+        }),
+        -- I couldn't get syntax highlight to work with this :(
+        previewer = nil,
+        sorter = conf.generic_sorter(opts),
+        attach_mappings = function(prompt_bufnr)
+            actions_set.select:replace(function()
+                local entry = state.get_selected_entry()
+                actions.close(prompt_bufnr)
+
+                local file_path_sans_norg_extension, _ = entry.value.file:gsub("%.norg$", "")
+                local just_file_name, _ = file_path_sans_norg_extension:gsub(".*%/", "")
+
+                vim.api.nvim_put(
+                    {
+                        "{"
+                            .. ":$/" .. file_path_sans_norg_extension .. ":"
+                            .. "}"
+                            .. "["
+                            .. just_file_name
+                            .. "]",
+                    },
+                    "c",
+                    false,
+                    true
+                )
+                vim.api.nvim_feedkeys("hf]a", "t", false)
+            end)
+            return true
+        end,
+    }):find()
+end

--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -69,7 +69,7 @@ return function(opts)
     opts = opts or {}
 
     pickers.new(opts, {
-        prompt_title = "Insert Link to norg File",
+        prompt_title = "Insert Link to Neorg File",
         results_title = "Linkables",
         finder = finders.new_table({
             results = generate_links(),


### PR DESCRIPTION
In response to this issue in neorg: https://github.com/nvim-neorg/neorg/issues/301
Here is a picker for norg files, inserting a link with the `$` workspace anchor