### PR TITLE
insert_file_link will now insert a link created by the prompt if there is no selection present

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Simply press a key (`<C-l>` in insert mode by default) and select what you want 
 ### Automatic File Link Insertion
 You can use `Telescope neorg insert_file_link` to insert a link to a neorg file.
 Notice that this only works for files in the current workspace.
-Note: the prompt will be used if no selection is chosen.
+Note: If no file is selected a link to a file with the name of the prompt value
+will be inserted. This file will be created if you use the link with 
+[neorg's hop](https://github.com/nvim-neorg/neorg/wiki/Esupports-Hop)
 
 ![insert_file_link](https://user-images.githubusercontent.com/81827001/153646847-c43aa368-b5b5-44ac-ba00-b3d98454650d.png)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Simply press a key (`<C-l>` in insert mode by default) and select what you want 
 ### Automatic File Link Insertion
 You can use `Telescope neorg insert_file_link` to insert a link to a neorg file.
 Notice that this only works for files in the current workspace.
+Note: the prompt will be used if no selection is chosen.
 
 ![insert_file_link](https://user-images.githubusercontent.com/81827001/153646847-c43aa368-b5b5-44ac-ba00-b3d98454650d.png)
 

--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -78,7 +78,7 @@ return function(opts)
                 local entry = state.get_selected_entry()
 
                 local path_no_extension
-        
+
                 if entry then
                   path_no_extension, _ = entry.value.file:gsub("%.norg$", "")
                 else

--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -76,9 +76,17 @@ return function(opts)
         attach_mappings = function(prompt_bufnr)
             actions_set.select:replace(function()
                 local entry = state.get_selected_entry()
+
+                local path_no_extension
+        
+                if entry then
+                  path_no_extension, _ = entry.value.file:gsub("%.norg$", "")
+                else
+                  path_no_extension = state.get_current_line()
+                end
+
                 actions.close(prompt_bufnr)
 
-                local path_no_extension, _ = entry.value.file:gsub("%.norg$", "")
                 local file_name, _ = path_no_extension:gsub(".*%/", "")
 
                 vim.api.nvim_put(


### PR DESCRIPTION
I think that this adds a nice option to the flow of inserting a file link, so that a new file can be created easily if hop is used on the newly generated link.

If there's anything that should be changed at all please let me know! 

Thanks for the awesome plugin!