### PR TITLE
fix bug with preemptive loading, and entry field bug in switch workplace

### DIFF
--- a/lua/telescope/_extensions/neorg/switch_workspace.lua
+++ b/lua/telescope/_extensions/neorg/switch_workspace.lua
@@ -13,15 +13,20 @@ local neorg_loaded, _ = pcall(require, "neorg.modules")
 
 assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first")
 
-local workspaces_raw = neorg.modules.get_module("core.norg.dirman").get_workspaces()
 local ns = vim.api.nvim_create_namespace("neorg-tele-workspace-preview")
-local workspaces = {}
 
-for name, path in pairs(workspaces_raw) do
-    table.insert(workspaces, { name = name, path = path })
-end
+local workspaces
 
 return function(options)
+    if not workspaces then
+        workspaces = {}
+
+        local workspaces_raw = neorg.modules.get_module("core.norg.dirman").get_workspaces()
+        for name, path in pairs(workspaces_raw) do
+            table.insert(workspaces, { name = name, path = path })
+        end
+    end
+
     local opts = options
         or themes.get_dropdown({
             border = true,
@@ -65,7 +70,8 @@ return function(options)
             action_set.select:replace(function()
                 local entry = state.get_selected_entry()
                 actions.close(prompt_bufnr)
-                neorg.modules.get_module("core.norg.dirman").open_workspace(entry[1])
+                Pr(entry)
+                neorg.modules.get_module("core.norg.dirman").open_workspace(entry.value.name)
             end)
             return true
         end,

--- a/lua/telescope/_extensions/neorg/switch_workspace.lua
+++ b/lua/telescope/_extensions/neorg/switch_workspace.lua
@@ -70,7 +70,6 @@ return function(options)
             action_set.select:replace(function()
                 local entry = state.get_selected_entry()
                 actions.close(prompt_bufnr)
-                Pr(entry)
                 neorg.modules.get_module("core.norg.dirman").open_workspace(entry.value.name)
             end)
             return true

--- a/lua/telescope/_extensions/neorg/switch_workspace.lua
+++ b/lua/telescope/_extensions/neorg/switch_workspace.lua
@@ -70,7 +70,9 @@ return function(options)
             action_set.select:replace(function()
                 local entry = state.get_selected_entry()
                 actions.close(prompt_bufnr)
-                neorg.modules.get_module("core.norg.dirman").open_workspace(entry.value.name)
+                if entry then
+                    neorg.modules.get_module("core.norg.dirman").open_workspace(entry.value.name)
+                end
             end)
             return true
         end,


### PR DESCRIPTION
fixes #19 

- [x] The dirman module was being loaded too before it was available, so I moved that into the switch workplaces function, but memoized it to maintain some perf advantages
- [x] The entry returned by telescope was a different shape than the one the switch_workplaces mod was expecting, so I took care of that while I was in the neighborhood.


This was the extra error in question 
```
E5108: Error executing lua ...tart/neorg/lua/neorg/modules/core/norg/dirman/module.lua:426: attempt to concatenate local 'workspa
ce' (a nil value)
stack traceback:
        ...tart/neorg/lua/neorg/modules/core/norg/dirman/module.lua:426: in function 'open_workspace'
        ...ope/lua/telescope/_extensions/neorg/switch_workspace.lua:73: in function 'run_replace_or_original'
        ...packer/start/telescope.nvim/lua/telescope/actions/mt.lua:65: in function 'run_replace_or_original'
        ...packer/start/telescope.nvim/lua/telescope/actions/mt.lua:65: in function 'key_func'
        ...k/packer/start/telescope.nvim/lua/telescope/mappings.lua:242: in function 'execute_keymap'
        [string ":lua"]:1: in main chunk
```
