### PR TITLE
fix: Get lines so search_headings won't be empty

### DIFF
--- a/lua/telescope/_extensions/neorg/search_headings.lua
+++ b/lua/telescope/_extensions/neorg/search_headings.lua
@@ -11,8 +11,6 @@ local neorg_loaded, _ = pcall(require, "neorg.modules")
 
 assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first")
 
-local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
-
 local bufnr = vim.api.nvim_get_current_buf()
 
 local filename = vim.fn.expand(vim.api.nvim_buf_get_name(bufnr))
@@ -24,13 +22,13 @@ return function(options)
     previewer = false,
     shorten_path = false,
     prompt_prefix = " ◈  ",
-    -- prompt_prefix = "  ",
     layout_config = {
       prompt_position = "top",
     },
   })
 
   local lines_with_numbers = {}
+  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
 
   for lnum, line in ipairs(lines) do
     local match = line:match("^%s*%*+%s+")


### PR DESCRIPTION
This change gets the buffer number and lines each time the search_headings command is called so the resultant list of headings won't be empty.

Hey all, I'm not too familiar with the repository but I did some quick digging and saw that search headings would have an empty list because "lines" wasn't valid and there'd be nothing to match against. You can test the command by running `Telescope neorg search_headings` but this should fix it. I saw someone in the discord mention they had the same issue.

Let me know if there's anything else I need to do etc to make it merge-able. Thank you.