### PR TITLE
Add find_norg_files picker

### DIFF
--- a/lua/neorg/modules/core/integrations/telescope/module.lua
+++ b/lua/neorg/modules/core/integrations/telescope/module.lua
@@ -19,6 +19,7 @@ module.load = function()
 
     module.required["core.keybinds"].register_keybinds(module.name, {
         "find_linkable",
+        "find_norg_files",
         "insert_link",
         "insert_file_link",
         "search_headings",
@@ -32,6 +33,7 @@ end
 
 module.public = {
     find_linkable = require("telescope._extensions.neorg.find_linkable"),
+    find_norg_files = require("telescope._extensions.neorg.find_norg_files"),
     insert_link = require("telescope._extensions.neorg.insert_link"),
     insert_file_link = require("telescope._extensions.neorg.insert_file_link"),
     search_headings = require("telescope._extensions.neorg.search_headings"),
@@ -45,6 +47,8 @@ module.public = {
 module.on_event = function(event)
     if event.split_type[2] == "core.integrations.telescope.find_linkable" then
         module.public.find_linkable()
+    elseif event.split_type[2] == "core.integrations.telescope.find_norg_files" then
+        module.public.find_norg_files()
     elseif event.split_type[2] == "core.integrations.telescope.insert_link" then
         module.public.insert_link()
     elseif event.split_type[2] == "core.integrations.telescope.insert_file_link" then
@@ -67,6 +71,7 @@ end
 module.events.subscribed = {
     ["core.keybinds"] = {
         ["core.integrations.telescope.find_linkable"] = true,
+        ["core.integrations.telescope.find_norg_files"] = true,
         ["core.integrations.telescope.insert_link"] = true,
         ["core.integrations.telescope.insert_file_link"] = true,
         ["core.integrations.telescope.search_headings"] = true,

--- a/lua/telescope/_extensions/neorg.lua
+++ b/lua/telescope/_extensions/neorg.lua
@@ -1,6 +1,7 @@
 return require("telescope").register_extension({
     exports = {
         find_linkable = require("neorg.modules.core.integrations.telescope.module").public.find_linkable,
+        find_norg_files = require("neorg.modules.core.integrations.telescope.module").public.find_norg_files,
         insert_link = require("neorg.modules.core.integrations.telescope.module").public.insert_link,
         insert_file_link = require("neorg.modules.core.integrations.telescope.module").public.insert_file_link,
         search_headings = require("neorg.modules.core.integrations.telescope.module").public.search_headings,
@@ -8,6 +9,6 @@ return require("telescope").register_extension({
         find_project_tasks = require("neorg.modules.core.integrations.telescope.module").public.find_project_tasks,
         find_aof_tasks = require("neorg.modules.core.integrations.telescope.module").public.find_aof_tasks,
         find_aof_project_tasks = require("neorg.modules.core.integrations.telescope.module").public.find_aof_project_tasks,
-        switch_workspace = require("neorg.modules.core.integrations.telescope.module").public.switch_workspace
+        switch_workspace = require("neorg.modules.core.integrations.telescope.module").public.switch_workspace,
     },
 })

--- a/lua/telescope/_extensions/neorg/find_norg_files.lua
+++ b/lua/telescope/_extensions/neorg/find_norg_files.lua
@@ -1,30 +1,47 @@
 local neorg_loaded, _ = pcall(require, "neorg.modules")
+local pickers = require("telescope.pickers")
+local finders = require("telescope.finders")
+local conf = require("telescope.config").values -- allows us to use the values from the users config
+local make_entry = require("telescope.make_entry")
 
 assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first")
 
-local function get_current_workspace()
+--- Get a list of all norg files in current workspace. Returns { workspace_path, norg_files }
+--- @return table?
+local function get_norg_files()
     local dirman = neorg.modules.get_module("core.norg.dirman")
 
-    if dirman then
-        local current_workspace = dirman.get_current_workspace()[2]
-
-        return current_workspace
+    if not dirman then
+        return nil
     end
 
-    return nil
+    local current_workspace = dirman.get_current_workspace()
+
+    local norg_files = dirman.get_norg_files(current_workspace[1])
+
+    return { current_workspace[2], norg_files }
 end
 
 return function(opts)
     opts = opts or {}
 
-    local current_workspace = get_current_workspace()
+    local files = get_norg_files()
 
-    if not current_workspace then
+    if not (files and files[2]) then
         return
     end
 
-    require("telescope.builtin").find_files({
-        search_dirs = { current_workspace },
-        prompt_title = opts.prompt_title or "Find Norg Files",
-    })
+    opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)
+
+    pickers
+        .new(opts, {
+            prompt_title = opts.prompt_title or "Find Norg Files",
+            cwd = files[1],
+            finder = finders.new_table({
+                results = files[2],
+            }),
+            previewer = conf.file_previewer(opts),
+            sorter = conf.file_sorter(opts),
+        })
+        :find()
 end

--- a/lua/telescope/_extensions/neorg/find_norg_files.lua
+++ b/lua/telescope/_extensions/neorg/find_norg_files.lua
@@ -1,0 +1,30 @@
+local neorg_loaded, _ = pcall(require, "neorg.modules")
+
+assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first")
+
+local function get_current_workspace()
+    local dirman = neorg.modules.get_module("core.norg.dirman")
+
+    if dirman then
+        local current_workspace = dirman.get_current_workspace()[2]
+
+        return current_workspace
+    end
+
+    return nil
+end
+
+return function(opts)
+    opts = opts or {}
+
+    local current_workspace = get_current_workspace()
+
+    if not current_workspace then
+        return
+    end
+
+    require("telescope.builtin").find_files({
+        search_dirs = { current_workspace },
+        prompt_title = "Find Norg Files",
+    })
+end

--- a/lua/telescope/_extensions/neorg/find_norg_files.lua
+++ b/lua/telescope/_extensions/neorg/find_norg_files.lua
@@ -25,6 +25,6 @@ return function(opts)
 
     require("telescope.builtin").find_files({
         search_dirs = { current_workspace },
-        prompt_title = "Find Norg Files",
+        prompt_title = opts.prompt_title or "Find Norg Files",
     })
 end


### PR DESCRIPTION
Often times when I use find_linkables I'm mostly looking for a way to quickly jump to a file in my norg workspace when I'm somewhere else. The clutter of seeing every heading in all my files and journals adds visual noise. 

Having a simple file picker that just iterates over all .norg files in your current workspace simplifies this task.

This just uses the builtin find_files with `search_dirs` set to the current neorg workspace