### PR TITLE
Updated the use of relative to absolute paths.

### DIFF
--- a/lua/telescope/_extensions/neorg/find_norg_files.lua
+++ b/lua/telescope/_extensions/neorg/find_norg_files.lua
@@ -18,6 +18,9 @@ local function get_norg_files()
     local current_workspace = dirman.get_current_workspace()
 
     local norg_files = dirman.get_norg_files(current_workspace[1])
+    for i, file in pairs(norg_files) do
+      norg_files[i] = current_workspace[2] .. "/" .. file
+    end
 
     return { current_workspace[2], norg_files }
 end


### PR DESCRIPTION
This is to fix #30. My not be the best solution given that you can use `:Telescope find_norg_files` from *anywhere* and you'll be able to view your norg files. This works similarly to setting `vim.opt.autochdir = true` in an ftplugin or your configs

![image](https://user-images.githubusercontent.com/44822875/224517086-720fc715-28ee-48c6-9694-b905143735cb.png)

One minor edit is that it will always show the absolute file path. Of course this has no issue with function. I'm just really hung up on the appearance lmao.