### PR TITLE
fix: `core.norg` -> `core`

### DIFF
--- a/lua/neorg/modules/core/integrations/telescope/module.lua
+++ b/lua/neorg/modules/core/integrations/telescope/module.lua
@@ -7,7 +7,7 @@ require("neorg.modules.base")
 local module = neorg.modules.create("core.integrations.telescope")
 
 module.setup = function()
-    return { success = true, requires = { "core.keybinds", "core.norg.dirman" } }
+    return { success = true, requires = { "core.keybinds", "core.dirman" } }
 end
 
 module.load = function()

--- a/lua/telescope/_extensions/neorg/find_linkable.lua
+++ b/lua/telescope/_extensions/neorg/find_linkable.lua
@@ -3,7 +3,7 @@ local neorg_loaded, _ = pcall(require, "neorg.modules")
 assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first")
 
 local function get_current_workspace()
-	local dirman = neorg.modules.get_module("core.norg.dirman")
+	local dirman = neorg.modules.get_module("core.dirman")
 
 	if dirman then
 		local current_workspace = dirman.get_current_workspace()[2]

--- a/lua/telescope/_extensions/neorg/find_norg_files.lua
+++ b/lua/telescope/_extensions/neorg/find_norg_files.lua
@@ -9,7 +9,7 @@ assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first
 --- Get a list of all norg files in current workspace. Returns { workspace_path, norg_files }
 --- @return table?
 local function get_norg_files()
-    local dirman = neorg.modules.get_module("core.norg.dirman")
+    local dirman = neorg.modules.get_module("core.dirman")
 
     if not dirman then
         return nil

--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -12,7 +12,7 @@ assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first
 --- Get a list of all norg files in current workspace. Returns { workspace_path, norg_files }
 --- @return table
 local function get_norg_files()
-    local dirman = neorg.modules.get_module("core.norg.dirman")
+    local dirman = neorg.modules.get_module("core.dirman")
 
     if not dirman then
         return nil
@@ -29,7 +29,7 @@ end
 --- @return table
 local function generate_links()
     local res = {}
-    local dirman = neorg.modules.get_module("core.norg.dirman")
+    local dirman = neorg.modules.get_module("core.dirman")
 
     if not dirman then
         return nil

--- a/lua/telescope/_extensions/neorg/insert_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_link.lua
@@ -13,7 +13,7 @@ assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first
 --- Get a list of all norg files in current workspace. Returns { workspace_path, norg_files }
 --- @return table
 local function get_norg_files()
-    local dirman = neorg.modules.get_module("core.norg.dirman")
+    local dirman = neorg.modules.get_module("core.dirman")
 
     if not dirman then
         return nil
@@ -60,7 +60,7 @@ end
 --- @return table
 local function generate_links()
     local res = {}
-    local dirman = neorg.modules.get_module("core.norg.dirman")
+    local dirman = neorg.modules.get_module("core.dirman")
 
     if not dirman then
         return nil

--- a/lua/telescope/_extensions/neorg/switch_workspace.lua
+++ b/lua/telescope/_extensions/neorg/switch_workspace.lua
@@ -21,7 +21,7 @@ return function(options)
     if not workspaces then
         workspaces = {}
 
-        local workspaces_raw = neorg.modules.get_module("core.norg.dirman").get_workspaces()
+        local workspaces_raw = neorg.modules.get_module("core.dirman").get_workspaces()
         for name, path in pairs(workspaces_raw) do
             table.insert(workspaces, { name = name, path = path })
         end
@@ -57,7 +57,7 @@ return function(options)
                 table.insert(lines, "Path:")
                 table.insert(lines, workspace.path)
                 table.insert(lines, "Files:")
-                local files = neorg.modules.get_module("core.norg.dirman").get_norg_files(workspace.name)
+                local files = neorg.modules.get_module("core.dirman").get_norg_files(workspace.name)
                 for _, file in ipairs(files) do
                     table.insert(lines, file)
                 end
@@ -71,7 +71,7 @@ return function(options)
                 local entry = state.get_selected_entry()
                 actions.close(prompt_bufnr)
                 if entry then
-                    neorg.modules.get_module("core.norg.dirman").open_workspace(entry.value.name)
+                    neorg.modules.get_module("core.dirman").open_workspace(entry.value.name)
                 end
             end)
             return true


### PR DESCRIPTION
rename of "core.norg.dirman" to "core.dirman" to account for nvim-neorg/neorg@a5824edf6893b8602e560ed7675c0d4174e263e4