### PR TITLE
Add find_linkable search in defenitions

### DIFF
--- a/lua/telescope/_extensions/neorg/find_linkable.lua
+++ b/lua/telescope/_extensions/neorg/find_linkable.lua
@@ -24,7 +24,7 @@ return function(opts)
     end
 
     require("telescope.builtin").grep_string({
-        search = "^\\s*(\\*+|\\|{1,2})\\s+",
+        search = "^\\s*(\\*+|\\|{1,2}|\\${1,2})\\s+",
         use_regex = true,
         search_dirs = { current_workspace },
         prompt_title = "Find in Norg files",


### PR DESCRIPTION
I use a lot of definitions in my notes. And I think that as long as it is possible to make links to defenitions, maybe it could be useful to see them in Telescope `find_linkable` search results.