### PR TITLE
Use metadata title instead of file name when inserting file link

### DIFF
--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -41,14 +41,27 @@ local function generate_links()
         return
     end
 
+    local ts = neorg.modules.get_module("core.integrations.treesitter")
+
     for _, file in pairs(files[2]) do
         local bufnr = dirman.get_file_bufnr(file)
+
+        local title = nil
+        local title_display = ""
+        if ts then
+            local metadata = ts.get_document_metadata(bufnr)
+            if metadata and metadata.title then
+                title = metadata.title
+                title_display = " [" .. title .. "]"
+            end
+        end
 
         if vim.api.nvim_get_current_buf() ~= bufnr then
             local links = {
                 file = file,
-                display = "$" .. file:sub(#files[1] + 1, -1),
+                display = "$" .. file:sub(#files[1] + 1, -1) .. title_display,
                 relative = file:sub(#files[1] + 1, -1):sub(0, -6),
+                title = title,
             }
             table.insert(res, links)
         end
@@ -72,6 +85,7 @@ return function(opts)
                         display = entry.display,
                         ordinal = entry.display,
                         relative = entry.relative,
+                        title = entry.title,
                     }
                 end,
             }),
@@ -95,7 +109,7 @@ return function(opts)
                     local file_name, _ = path_no_extension:gsub(".*%/", "")
 
                     vim.api.nvim_put({
-                        "{" .. ":$" .. entry.relative .. ":" .. "}" .. "[" .. file_name .. "]",
+                        "{" .. ":$" .. entry.relative .. ":" .. "}" .. "[" .. (entry.title or file_name) .. "]",
                     }, "c", false, true)
                     vim.api.nvim_feedkeys("hf]a", "t", false)
                 end)


### PR DESCRIPTION

![neorg-telescope-title-01](https://github.com/nvim-neorg/neorg-telescope/assets/2861357/22145e86-0596-4507-aabe-464a3fb403b1)

![neorg-telescope-title-02](https://github.com/nvim-neorg/neorg-telescope/assets/2861357/49942fdf-aa3e-4fc8-ad59-dd9bd8a402db)


- It's more readable and reasonable to display title in link.
- Only apply this behavior when treesitter and metadata title are available.
- Provide the telescope fuzzy search on title as well.