### PR TITLE
Remove previewer from switch_workspaces

### DIFF
--- a/lua/telescope/_extensions/neorg/switch_workspace.lua
+++ b/lua/telescope/_extensions/neorg/switch_workspace.lua
@@ -7,7 +7,6 @@ local action_set = require("telescope.actions.set")
 local action_state = require("telescope.actions.state")
 local state = require("telescope.actions.state")
 local conf = require("telescope.config").values
-local previewers = require("telescope.previewers")
 
 local neorg_loaded, neorg = pcall(require, "neorg.core")
 

--- a/lua/telescope/_extensions/neorg/switch_workspace.lua
+++ b/lua/telescope/_extensions/neorg/switch_workspace.lua
@@ -51,22 +51,6 @@ return function(options)
                 end,
             }),
             sorter = conf.generic_sorter(opts),
-            previewer = previewers.new_buffer_previewer({
-                define_preview = function(self, entry, status)
-                    local workspace = entry.value
-                    local lines = {}
-                    table.insert(lines, "Path:")
-                    table.insert(lines, workspace.path)
-                    table.insert(lines, "Files:")
-                    local files = neorg.modules.get_module("core.dirman").get_norg_files(workspace.name)
-                    for _, file in ipairs(files) do
-                        table.insert(lines, file)
-                    end
-                    vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, true, lines)
-                    vim.api.nvim_buf_add_highlight(self.state.bufnr, ns, "Special", 0, 0, -1)
-                    vim.api.nvim_buf_add_highlight(self.state.bufnr, ns, "Special", 2, 0, -1)
-                end,
-            }),
             attach_mappings = function(prompt_bufnr)
                 action_set.select:replace(function()
                     local entry = state.get_selected_entry()


### PR DESCRIPTION
First of all, thanks for creating this library! Discovered it today and I'm already loving it!

Second, sorry if there is any errors. This is my first ever contribution to a project 😅 

Third, I was poking around and I found a `switch_workspace` function that comes very handy. I haven't found any references to it in the docs so I assume it would be broken 😅 

Turns out that when I tested it, my Neovim completely frozen, forcing me to restart it.

I was able to fix the issue by completely removing the previewer from the Telescope filter. After removing it, the command works like a breeze! 🙌🏻 

I personally don't find it very useful when switching workspaces, but I also understand that it might be interesting for other people. Therefore I'd like to have your take on it 😃 

I thought of making it optional through a config flag, but I haven't understood how to access the configs of a module so I could check it from. If you think that's more reasonable than just removing it and can guide me through how to access configuration, I'd happy to change it!

Thanks!