### PR TITLE
fix: cursor behavior on link insertion

### DIFF
--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -72,6 +72,7 @@ end
 
 return function(opts)
     opts = opts or {}
+    local mode = vim.api.nvim_get_mode().mode
 
     pickers
         .new(opts, {
@@ -110,8 +111,10 @@ return function(opts)
 
                     vim.api.nvim_put({
                         "{" .. ":$" .. entry.relative .. ":" .. "}" .. "[" .. (entry.title or file_name) .. "]",
-                    }, "c", false, true)
-                    vim.api.nvim_feedkeys("hf]a", "t", false)
+                    }, "c", true, true)
+                    if mode == "i" then
+                        vim.api.nvim_feedkeys("a", "n", false)
+                    end
                 end)
                 return true
             end,

--- a/lua/telescope/_extensions/neorg/insert_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_link.lua
@@ -95,6 +95,7 @@ end
 return function(opts)
     opts = opts or {}
     local links = generate_links()
+    local mode = vim.api.nvim_get_mode().mode
 
     pickers
         .new(opts, {
@@ -158,16 +159,18 @@ return function(opts)
                                 "[%*#%|_]",
                                 "\\%1"
                             ) .. "}" .. "[" .. entry.linkable:gsub(":$", "") .. "]",
-                        }, "c", false, true)
+                        }, "c", true, true)
                     else
                         vim.api.nvim_put({
                             "{" .. inserted_file .. entry.ordinal:gsub("^(%W+)%s+.+", "%1 ") .. entry.linkable:gsub(
                                 "[%*#%|_]",
                                 "\\%1"
                             ) .. "}",
-                        }, "c", false, true)
+                        }, "c", true, true)
                     end
-                    vim.api.nvim_feedkeys("hf]a", "t", false)
+                    if mode == "i" then
+                        vim.api.nvim_feedkeys("a", "n", false)
+                    end
                 end)
                 return true
             end,


### PR DESCRIPTION
Hi; this PR fixes the cursor behavior when users had some of the keys remapped that where fed via `nvim_feedkeys`. It should also fix #37.

However, note that to do this I basically changed `nvim_feedkeys("hf]a", "t")` to `nvim_feekeys("a", "n")`. Why was "hf]" there in the first place; shouldn't `nvim_put("...", false, true)` place the cursor at the end of the inserted text anyways, or am I'm missing some edge cases here? I'm a little bit uncertain about that.

Additionally, the behavior is changed such that insert mode is only entered if the action was started from insert mode, and the putting behaves like `p` instead of `P`. The latter change is debatable, but for me at least, it felt more natural that way; if you think differently I'll change it back.