### PR TITLE
feat: ws relative file/header backlink pickers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+
+[*]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,3 @@
-
 [*]
 indent_style = space
 indent_size = 4

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ With `Telescope neorg search_headings` you can search through all the headings i
 </details>
 
 ### Search File and Heading Backlinks
+- `Telescope neorg find_backlinks` - find every line in your workspace that links^* to the current file
+- `Telescope neorg find_header_backlinks` - same but with links to the current file _and_ heading
+
 These are limited to workspace relative links (ie.
 `{:$/worspace/relative/path:}`) for the sake of simplicity. Both exact
 (`{:$/path:** lvl 2 heading}`) and fuzzy (`{:$/path:# heading}`) links are
@@ -50,11 +53,8 @@ found.
 <details>
   <summary>Demo</summary>
 
-![search backlink](https://github.com/benlubas/neorg-telescope/assets/56943754/1332f319-cf43-4a5b-902a-f2bbe4ea14e3)
-
+![search backlink](https://github.com/nvim-neorg/neorg-telescope/assets/56943754/37a5b68f-29b3-43ae-a679-9656cfa646db)
 </details>
-
-
 
 ## Gtd Pickers
 ### Those pickers are all broken since gtd was removed in core

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ With `Telescope neorg search_headings` you can search through all the headings i
 <img alt="search_headings" src="https://user-images.githubusercontent.com/81827001/153647155-80f5579f-acc9-489e-9e05-acf31a646bba.png">
 </details>
 
+### Search File and Heading Backlinks
+These are limited to workspace relative links (ie.
+`{:$/worspace/relative/path:}`) for the sake of simplicity. Both exact
+(`{:$/path:** lvl 2 heading}`) and fuzzy (`{:$/path:# heading}`) links are
+found.
+
+<details>
+  <summary>Demo</summary>
+
+![search backlink](https://github.com/benlubas/neorg-telescope/assets/56943754/1332f319-cf43-4a5b-902a-f2bbe4ea14e3)
+
+</details>
+
+
+
 ## Gtd Pickers
 ### Those pickers are all broken since gtd was removed in core
 <details>

--- a/lua/neorg/modules/core/integrations/telescope/module.lua
+++ b/lua/neorg/modules/core/integrations/telescope/module.lua
@@ -28,6 +28,8 @@ module.load = function()
         "find_aof_tasks",
         "find_context_tasks",
         "switch_workspace",
+        "find_backlinks",
+        "find_header_backlinks",
     })
 end
 
@@ -42,6 +44,8 @@ module.public = {
     find_aof_tasks = require("telescope._extensions.neorg.find_aof_tasks"),
     find_aof_project_tasks = require("telescope._extensions.neorg.find_aof_project_tasks"),
     switch_workspace = require("telescope._extensions.neorg.switch_workspace"),
+    find_backlinks = require("telescope._extensions.neorg.backlinks.file_backlinks"),
+    find_header_backlinks = require("telescope._extensions.neorg.backlinks.header_backlinks"),
 }
 
 module.on_event = function(event)
@@ -65,6 +69,10 @@ module.on_event = function(event)
         module.public.find_context_tasks()
     elseif event.split_type[2] == "core.integrations.telescope.switch_workspace" then
         module.public.switch_workspace()
+    elseif event.split_type[2] == "core.integrations.telescope.find_backlinks" then
+        module.public.find_backlinks()
+    elseif event.split_type[2] == "core.integrations.telescope.find_header_backlinks" then
+        module.public.find_header_backlinks()
     end
 end
 
@@ -80,6 +88,8 @@ module.events.subscribed = {
         ["core.integrations.telescope.find_aof_tasks"] = true,
         ["core.integrations.telescope.find_aof_project_tasks"] = true,
         ["core.integrations.telescope.switch_workspace"] = true,
+        ["core.integrations.telescope.find_backlinks"] = true,
+        ["core.integrations.telescope.find_header_backlinks"] = true,
     },
 }
 

--- a/lua/neorg/telescope_utils.lua
+++ b/lua/neorg/telescope_utils.lua
@@ -152,4 +152,15 @@ utils.get_project_tasks = function()
     return projects_tasks
 end
 
+---Gets the full path to the current workspace
+---@return string?
+utils.get_current_workspace = function()
+    local dirman = neorg.modules.get_module("core.dirman")
+    if dirman then
+        local current_workspace = dirman.get_current_workspace()[2]
+        return current_workspace
+    end
+    return nil
+end
+
 return utils

--- a/lua/telescope/_extensions/neorg.lua
+++ b/lua/telescope/_extensions/neorg.lua
@@ -10,5 +10,7 @@ return require("telescope").register_extension({
         find_aof_tasks = require("neorg.modules.core.integrations.telescope.module").public.find_aof_tasks,
         find_aof_project_tasks = require("neorg.modules.core.integrations.telescope.module").public.find_aof_project_tasks,
         switch_workspace = require("neorg.modules.core.integrations.telescope.module").public.switch_workspace,
+        find_backlinks = require("neorg.modules.core.integrations.telescope.module").public.find_backlinks,
+        find_header_backlinks = require("neorg.modules.core.integrations.telescope.module").public.find_header_backlinks,
     },
 })

--- a/lua/telescope/_extensions/neorg/backlinks/common.lua
+++ b/lua/telescope/_extensions/neorg/backlinks/common.lua
@@ -1,10 +1,12 @@
+local M = {}
+
 ---produce the regular expression used to find workspace relative paths to the given file.
 ---Optionally takes a header that should exist in the current file
 ---@param workspace_path string "/abs/path/to/workspace"
 ---@param current_file string "test.norg"
 ---@param heading string? "** heading"
 ---@return string
-return function(workspace_path, current_file, heading)
+M.build_backlink_regex = function(workspace_path, current_file, heading)
     current_file = vim.api.nvim_buf_get_name(0)
     current_file = current_file:gsub("%.norg$", "")
     current_file = current_file:gsub("^" .. workspace_path .. "/", "")
@@ -21,3 +23,5 @@ return function(workspace_path, current_file, heading)
     heading_text = heading_text:gsub("^%(.%)%s?", "")
     return ([[\{:\$/%s:(#|%s) %s\}]]):format(current_file, heading_prefix, heading_text) -- {:$/workspace_path:(# heading or ** heading)}
 end
+
+return M

--- a/lua/telescope/_extensions/neorg/backlinks/file_backlinks.lua
+++ b/lua/telescope/_extensions/neorg/backlinks/file_backlinks.lua
@@ -1,23 +1,8 @@
-local neorg_loaded, neorg = pcall(require, "neorg.core")
-
-assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first")
-
-local file_backlink_regex = require("telescope._extensions.neorg.backlinks.utils")
-
-local function get_current_workspace()
-    local dirman = neorg.modules.get_module("core.dirman")
-
-    if dirman then
-        local current_workspace = dirman.get_current_workspace()[2]
-
-        return current_workspace
-    end
-
-    return nil
-end
+local common = require("telescope._extensions.neorg.backlinks.common")
+local utils = require("neorg.telescope_utils")
 
 return function()
-    local current_workspace = get_current_workspace()
+    local current_workspace = utils.get_current_workspace()
 
     if not current_workspace then
         return
@@ -26,7 +11,7 @@ return function()
     local current_file = vim.api.nvim_buf_get_name(0)
 
     require("telescope.builtin").grep_string({
-        search = file_backlink_regex(current_workspace, current_file),
+        search = common.build_backlink_regex(current_workspace, current_file),
         use_regex = true,
         search_dirs = { current_workspace },
         prompt_title = "File Backlinks",

--- a/lua/telescope/_extensions/neorg/backlinks/file_backlinks.lua
+++ b/lua/telescope/_extensions/neorg/backlinks/file_backlinks.lua
@@ -16,9 +16,7 @@ local function get_current_workspace()
     return nil
 end
 
-return function(opts)
-    opts = opts or {}
-
+return function()
     local current_workspace = get_current_workspace()
 
     if not current_workspace then
@@ -31,6 +29,6 @@ return function(opts)
         search = file_backlink_regex(current_workspace, current_file),
         use_regex = true,
         search_dirs = { current_workspace },
-        prompt_title = "Backlinks to Current File",
+        prompt_title = "File Backlinks",
     })
 end

--- a/lua/telescope/_extensions/neorg/backlinks/file_backlinks.lua
+++ b/lua/telescope/_extensions/neorg/backlinks/file_backlinks.lua
@@ -1,0 +1,36 @@
+local neorg_loaded, neorg = pcall(require, "neorg.core")
+
+assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first")
+
+local file_backlink_regex = require("telescope._extensions.neorg.backlinks.utils")
+
+local function get_current_workspace()
+    local dirman = neorg.modules.get_module("core.dirman")
+
+    if dirman then
+        local current_workspace = dirman.get_current_workspace()[2]
+
+        return current_workspace
+    end
+
+    return nil
+end
+
+return function(opts)
+    opts = opts or {}
+
+    local current_workspace = get_current_workspace()
+
+    if not current_workspace then
+        return
+    end
+
+    local current_file = vim.api.nvim_buf_get_name(0)
+
+    require("telescope.builtin").grep_string({
+        search = file_backlink_regex(current_workspace, current_file),
+        use_regex = true,
+        search_dirs = { current_workspace },
+        prompt_title = "Backlinks to Current File",
+    })
+end

--- a/lua/telescope/_extensions/neorg/backlinks/header_backlinks.lua
+++ b/lua/telescope/_extensions/neorg/backlinks/header_backlinks.lua
@@ -1,0 +1,55 @@
+local neorg_loaded, neorg = pcall(require, "neorg.core")
+
+assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first")
+
+local file_backlink_regex = require("telescope._extensions.neorg.backlinks.utils")
+
+local function get_current_workspace()
+    local dirman = neorg.modules.get_module("core.dirman")
+
+    if dirman then
+        local current_workspace = dirman.get_current_workspace()[2]
+
+        return current_workspace
+    end
+
+    return nil
+end
+
+return function(opts)
+    opts = opts or {}
+
+    local current_workspace = get_current_workspace()
+
+    if not current_workspace then
+        return
+    end
+
+    local current_file = vim.api.nvim_buf_get_name(0)
+    local linenr = vim.api.nvim_win_get_cursor(0)[1]
+    local lines = vim.api.nvim_buf_get_lines(0, 0, linenr, false)
+    local heading = nil
+
+    -- HACK: iterate backward (up) over lines, and use the first heading we find. We should be using
+    -- TS instead, but I'm not super familiar with how to do things like that.
+    for i = #lines, 1, -1 do
+        local line = lines[i]
+        local potential_heading = line:match("^%s*%*+ .*$")
+        if potential_heading then
+            heading = potential_heading
+            break
+        end
+    end
+
+    if not heading then
+        vim.notify("[Neorg Telescope] Couldn't find current heading", vim.log.levels.ERROR)
+        return
+    end
+
+    require("telescope.builtin").grep_string({
+        search = file_backlink_regex(current_workspace, current_file, heading),
+        use_regex = true,
+        search_dirs = { current_workspace },
+        prompt_title = "Backlinks to " .. heading,
+    })
+end

--- a/lua/telescope/_extensions/neorg/backlinks/header_backlinks.lua
+++ b/lua/telescope/_extensions/neorg/backlinks/header_backlinks.lua
@@ -16,9 +16,7 @@ local function get_current_workspace()
     return nil
 end
 
-return function(opts)
-    opts = opts or {}
-
+return function()
     local current_workspace = get_current_workspace()
 
     if not current_workspace then
@@ -50,6 +48,6 @@ return function(opts)
         search = file_backlink_regex(current_workspace, current_file, heading),
         use_regex = true,
         search_dirs = { current_workspace },
-        prompt_title = "Backlinks to " .. heading,
+        prompt_title = "Header Backlinks (" .. heading .. ")",
     })
 end

--- a/lua/telescope/_extensions/neorg/backlinks/header_backlinks.lua
+++ b/lua/telescope/_extensions/neorg/backlinks/header_backlinks.lua
@@ -1,23 +1,8 @@
-local neorg_loaded, neorg = pcall(require, "neorg.core")
-
-assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first")
-
-local file_backlink_regex = require("telescope._extensions.neorg.backlinks.utils")
-
-local function get_current_workspace()
-    local dirman = neorg.modules.get_module("core.dirman")
-
-    if dirman then
-        local current_workspace = dirman.get_current_workspace()[2]
-
-        return current_workspace
-    end
-
-    return nil
-end
+local common = require("telescope._extensions.neorg.backlinks.common")
+local utils = require("neorg.telescope_utils")
 
 return function()
-    local current_workspace = get_current_workspace()
+    local current_workspace = utils.get_current_workspace()
 
     if not current_workspace then
         return
@@ -45,7 +30,7 @@ return function()
     end
 
     require("telescope.builtin").grep_string({
-        search = file_backlink_regex(current_workspace, current_file, heading),
+        search = common.build_backlink_regex(current_workspace, current_file, heading),
         use_regex = true,
         search_dirs = { current_workspace },
         prompt_title = "Header Backlinks (" .. heading .. ")",

--- a/lua/telescope/_extensions/neorg/backlinks/utils.lua
+++ b/lua/telescope/_extensions/neorg/backlinks/utils.lua
@@ -1,4 +1,4 @@
----produce the rg regular expression used to find workspace relative paths to the given file.
+---produce the regular expression used to find workspace relative paths to the given file.
 ---Optionally takes a header that should exist in the current file
 ---@param workspace_path string "/abs/path/to/workspace"
 ---@param current_file string "test.norg"
@@ -21,4 +21,3 @@ return function(workspace_path, current_file, heading)
     heading_text = heading_text:gsub("^%(.%)%s?", "")
     return ([[\{:\$/%s:(#|%s) %s\}]]):format(current_file, heading_prefix, heading_text) -- {:$/workspace_path:(# heading or ** heading)}
 end
-

--- a/lua/telescope/_extensions/neorg/backlinks/utils.lua
+++ b/lua/telescope/_extensions/neorg/backlinks/utils.lua
@@ -1,0 +1,24 @@
+---produce the rg regular expression used to find workspace relative paths to the given file.
+---Optionally takes a header that should exist in the current file
+---@param workspace_path string "/abs/path/to/workspace"
+---@param current_file string "test.norg"
+---@param heading string? "** heading"
+---@return string
+return function(workspace_path, current_file, heading)
+    current_file = vim.api.nvim_buf_get_name(0)
+    current_file = current_file:gsub("%.norg$", "")
+    current_file = current_file:gsub("^" .. workspace_path .. "/", "")
+
+    if not heading then
+        return ([[\{:\$/%s:.*\}]]):format(current_file) -- {:$/workspace_path:}
+    end
+
+    local heading_prefix = heading:match("^%**")
+    if heading_prefix then
+        heading_prefix = heading_prefix:gsub("%*", "\\*")
+    end
+    local heading_text = heading:gsub("^%** ", "")
+    heading_text = heading_text:gsub("^%(.%)%s?", "")
+    return ([[\{:\$/%s:(#|%s) %s\}]]):format(current_file, heading_prefix, heading_text) -- {:$/workspace_path:(# heading or ** heading)}
+end
+

--- a/lua/telescope/_extensions/neorg/find_linkable.lua
+++ b/lua/telescope/_extensions/neorg/find_linkable.lua
@@ -1,23 +1,9 @@
-local neorg_loaded, neorg = pcall(require, "neorg.core")
-
-assert(neorg_loaded, "Neorg is not loaded - please make sure to load Neorg first")
-
-local function get_current_workspace()
-    local dirman = neorg.modules.get_module("core.dirman")
-
-    if dirman then
-        local current_workspace = dirman.get_current_workspace()[2]
-
-        return current_workspace
-    end
-
-    return nil
-end
+local utils = require("neorg.telescope_utils")
 
 return function(opts)
     opts = opts or {}
 
-    local current_workspace = get_current_workspace()
+    local current_workspace = utils.get_current_workspace()
 
     if not current_workspace then
         return


### PR DESCRIPTION
closes #49

This is the "backlink picker at home". It's a simple, incomplete, implementation that is "good enough".

https://github.com/nvim-neorg/neorg-telescope/assets/56943754/37a5b68f-29b3-43ae-a679-9656cfa646db

It *does*:
- find workspace relative backlinks to the current file or header
- uses `rg` regex to find links
- uses lua patterns to find the current heading (searches up until it hits one)

It *does not*:
- handle relative path links
- use TS to find the current heading
- find links to footnotes

I, and others want a simple backlink functionality now while we wait for these features to be properly implemented in Neorg. So that's what this is, something to hold us over while we wait for the real thing.
