### PR TITLE
feat: added icons and preview to `insert_file_link` and `insert_link`

### DIFF
--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -74,15 +74,18 @@ local function generate_links(preview)
             if preview then
                 title = get_file_title(file)
                 if title then
-                    title_display = " [" .. title .. "]"
+                    title_display = "| " .. title
                 end
             end
 
             file = Path(file)
             local relative = file:relative_to(Path(files[1]))
+            local relative_string = relative:remove_suffix(".norg"):tostring()
+
+            local padding = 100 - #relative_string
             local links = {
                 file = file,
-                display = "$/" .. relative .. title_display,
+                display = "󰈙 " .. relative_string .. string.rep(" ", padding) .. title_display,
                 relative = relative:remove_suffix(".norg"),
                 title = title,
             }
@@ -106,6 +109,7 @@ return function(opts)
                 entry_maker = function(entry)
                     return {
                         value = entry,
+                        path = entry.file:tostring(),
                         display = entry.display,
                         ordinal = entry.display,
                         relative = entry.relative,
@@ -115,7 +119,7 @@ return function(opts)
                 end,
             }),
             -- I couldn't get syntax highlight to work with this :(
-            previewer = nil,
+            previewer = conf.file_previewer(opts),
             sorter = conf.generic_sorter(opts),
             attach_mappings = function(prompt_bufnr)
                 actions_set.select:replace(function()

--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -74,19 +74,17 @@ local function generate_links(preview)
             if preview then
                 title = get_file_title(file)
                 if title then
-                    title_display = "| " .. title
+                    title_display = " [" .. title .. "]"
                 end
             end
 
             file = Path(file)
-            local relative = file:relative_to(Path(files[1]))
-            local relative_string = relative:remove_suffix(".norg"):tostring()
+            local relative = file:relative_to(Path(files[1])):tostring()
 
-            local padding = 100 - #relative_string
             local links = {
                 file = file,
-                display = "󰈙 " .. relative_string .. string.rep(" ", padding) .. title_display,
-                relative = relative:remove_suffix(".norg"),
+                display = "$/" .. relative .. title_display,
+                relative = relative,
                 title = title,
             }
             table.insert(res, links)
@@ -118,7 +116,6 @@ return function(opts)
                     }
                 end,
             }),
-            -- I couldn't get syntax highlight to work with this :(
             previewer = conf.file_previewer(opts),
             sorter = conf.generic_sorter(opts),
             attach_mappings = function(prompt_bufnr)

--- a/lua/telescope/_extensions/neorg/insert_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_link.lua
@@ -39,7 +39,7 @@ local function get_linkables(bufnr, file, workspace)
     if file then
         lines = vim.fn.readfile(file:tostring("/"))
         path = file
-        file = " " .. file:relative_to(workspace):remove_suffix(".norg")
+        file = "$/" .. file:relative_to(workspace):remove_suffix(".norg")
     else
         lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
     end
@@ -115,16 +115,16 @@ return function(opts)
                 results = links,
                 entry_maker = function(entry)
                     local displayer = entry_display.create({
-                        separator = " | ",
+                        separator = "",
                         items = {
-                            { width = 100 },
+                            { width = 55 },
                             { remaining = true },
                         },
                     })
                     local function make_display(ent)
                         if entry.file then
                             return displayer({
-                                { ent.file,    "NeorgLinkFile" },
+                                { ent.file, "NeorgLinkFile" },
                                 { ent.ordinal, "NeorgLinkText" },
                             })
                         else
@@ -148,7 +148,6 @@ return function(opts)
                     }
                 end,
             }),
-            -- I couldn't get syntax highlight to work with this :(
             previewer = conf.file_previewer(opts),
             sorter = conf.generic_sorter(opts),
             attach_mappings = function(prompt_bufnr)
@@ -159,7 +158,7 @@ return function(opts)
                     local inserted_file = (function()
                         if entry.file then
                             -- entry.display = string.gsub(entry.display, entry.file..": ", "")
-                            return ":" .. string.gsub(entry.file, " ", "$/") .. ":"
+                            return ":" .. entry.file .. ":"
                         else
                             return ""
                         end


### PR DESCRIPTION
Hello, I've added icons and preview window to the `insert_file_link` and `insert_link` functions. 

<img width="1443" alt="image" src="https://github.com/user-attachments/assets/2ab05666-a555-4416-b31a-c6f2a435938f">

To get syntax highlighting, I added this to my Neovim config.

```lua
require("plenary.filetype").add_table {
  extension = {
    ["norg"] = "norg",
  },
}
```
