### PR TITLE
fix: nil check entry.path

### DIFF
--- a/lua/telescope/_extensions/neorg/insert_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_link.lua
@@ -144,7 +144,7 @@ return function(opts)
                         lnum = entry.line,
                         file = entry.file and tostring(entry.file) or nil,
                         linkable = entry.linkable,
-                        path = (entry.path and tostring(entry.path)) or vim.api.nvim_buf_get_name(0),
+                        path = entry.path and tostring(entry.path) or vim.api.nvim_buf_get_name(0),
                     }
                 end,
             }),

--- a/lua/telescope/_extensions/neorg/insert_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_link.lua
@@ -144,7 +144,7 @@ return function(opts)
                         lnum = entry.line,
                         file = entry.file and tostring(entry.file) or nil,
                         linkable = entry.linkable,
-                        path = entry.path:tostring(),
+                        path = (entry.path and tostring(entry.path)) or vim.api.nvim_buf_get_name(0),
                     }
                 end,
             }),


### PR DESCRIPTION
from the issue discussed on discord.

Here's some context from discord:

It looks like linking to the same file might cause problems?
Like, I can see that generate_links() is able to pass nil as the file to get_linkables() here:
```lua
local file_inserted = (function()
    if vim.api.nvim_get_current_buf() == bufnr then
        return nil
    else
        return Path(file)
    end
end)()
local links = get_linkables(bufnr, file_inserted, Path(current_workspace[2]))
```
```lua
local function get_linkables(bufnr, file, workspace)
    local ret = {}

    local path
    local lines
    if file then
        lines = vim.fn.readfile(file:tostring("/"))
        path = file
        file = "$/" .. file:relative_to(workspace):remove_suffix(".norg")
    else
        lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
    end
--- ...
        table.insert(
            ret,
            { line = i, linkable = marker_or_drawer[2], display = marker_or_drawer[1], file = file, path = path }
        )
    end
end
return ret
```

And then those values are the values passed to entry maker I think?