### PR TITLE
Ensure buffer is loaded before passing to treesitter to get metadata

### DIFF
--- a/lua/telescope/_extensions/neorg/insert_file_link.lua
+++ b/lua/telescope/_extensions/neorg/insert_file_link.lua
@@ -39,6 +39,7 @@ local function get_file_title(file)
         return nil
     end
 
+    local _ = vim.fn.bufload(tostring(file))
     local metadata = ts.get_document_metadata(file)
     if not metadata or not metadata.title then
         return nil


### PR DESCRIPTION
Currently, when inserting a link without the preview active, if the buffer has not yet been loaded by neovim, it will fail to get the title and throw an error. This change ensures that the buffer is then loaded if needed and the metadata can be read from treesitter to retrieve the title.